### PR TITLE
Fix template resolution and Transfer alias handling

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -31,7 +31,9 @@ def settle(payload: SettleRequest) -> SettleResponse:
 
     balances = [Balance(person=p, amount=a) for p, a in balances_map.items()]
     transfers = [
-        Transfer(from_=t["from"], to=t["to"], amount=t["amount"], currency=payload.base_currency)
+        Transfer(
+            **{"from": t["from"], "to": t["to"], "amount": t["amount"], "currency": payload.base_currency}
+        )
         for t in transfers_raw
     ]
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from pathlib import Path
 
 from .api import router as api_router
 
 app = FastAPI(title="Trip Splitter")
 
-templates = Jinja2Templates(directory="app/web/templates")
-app.mount("/static", StaticFiles(directory="app/web/static"), name="static")
+BASE_DIR = Path(__file__).resolve().parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "web" / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "web" / "static")), name="static")
 
 
 @app.get("/health")

--- a/tests/test_template_paths.py
+++ b/tests/test_template_paths.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+import importlib
+import sys
+
+
+def test_should_render_template_when_cwd_diff(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop("app.main", None)
+    main = importlib.import_module("app.main")
+    client = TestClient(main.app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Trip Splitter" in resp.content


### PR DESCRIPTION
## Summary
- Correct Transfer creation to populate the `from` alias properly
- Resolve template and static directories relative to `main.py`
- Test template rendering works when starting from a different working directory

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c0426c56ac8327b548c0c75e0e2ac5