### PR TITLE
fix(api): preserve precision in chart values

### DIFF
--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -14,13 +14,15 @@
     <script>
       // Minimal placeholder chart; real data will be provided by API
       const ctx = document.getElementById('balances-chart').getContext('2d');
+      const labels = ['Alice', 'Bob', 'Carol'];
+      const values = ['-65.30', '50.50', '14.80'].map(Number);
       new Chart(ctx, {
         type: 'bar',
         data: {
-          labels: ['Alice', 'Bob', 'Carol'],
+          labels: labels,
           datasets: [{
             label: 'Balances (USD)',
-            data: [-65.3, 50.5, 14.8],
+            data: values,
             backgroundColor: ['#ff8a80', '#80d8ff', '#ccff90'],
           }]
         },

--- a/tests/test_settle_e2e.py
+++ b/tests/test_settle_e2e.py
@@ -64,6 +64,9 @@ def test_should_return_json_response_with_balances_transfers_and_chart():
         {"from": "Alice", "to": "Carol", "amount": Decimal("14.80"), "currency": "USD"},
     ]
     assert data["chart"]["labels"] == ["Alice", "Bob", "Carol"]
+    assert data["chart"]["values"] == [b["amount"] for b in data["balances"]]
+    chart_values = [Decimal(v) for v in data["chart"]["values"]]
+    assert chart_values == [balances[name] for name in data["chart"]["labels"]]
 
 
 def test_should_validate_payload_and_return_422_on_bad_input():


### PR DESCRIPTION
## Summary
- send chart values as strings to avoid float rounding
- parse numeric strings on frontend Chart.js init
- test that chart values match balances precisely

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c0426960408327aed1ac3705c45a89