### PR TITLE
feat(api): return 501 when optimize exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ curl http://localhost:8000/health
 
 
 ## 已知限制與後續路線圖
-- `optimize=exact` 尚未實作（將限制在小 n，預計以 ILP/最少邊網路流）。
+- `optimize=exact` 尚未實作（將限制在小 n，預計以 ILP/最少邊網路流）。若指定 `optimize="exact"`，API 將回傳 501，訊息為 `exact mode not implemented`。
 - 單頁 UI 目前為最小可用，尚未串接 HTMX 表單互動與即時刷新。
 - 依幣別決定顯示位數（如 JPY 0 位）可透過 `rounding.places` 調整，但尚未做幣別級策略表。
 

--- a/app/api.py
+++ b/app/api.py
@@ -23,15 +23,13 @@ def settle(payload: SettleRequest) -> SettleResponse:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
     # Build transfers
-    if payload.optimize == "greedy":
-        transfers_raw = suggest_transfers_greedy(balances_map, places=payload.rounding.places)
-    else:
-        # Optional exact mode not implemented; default to greedy for now
-        transfers_raw = suggest_transfers_greedy(balances_map, places=payload.rounding.places)
+    if payload.optimize != "greedy":
+        raise HTTPException(status_code=501, detail="exact mode not implemented")
+    transfers_raw = suggest_transfers_greedy(balances_map, places=payload.rounding.places)
 
     balances = [Balance(person=p, amount=a) for p, a in balances_map.items()]
     transfers = [
-        Transfer(from_=t["from"], to=t["to"], amount=t["amount"], currency=payload.base_currency)
+        Transfer(**t, currency=payload.base_currency)
         for t in transfers_raw
     ]
 

--- a/tests/test_settle_e2e.py
+++ b/tests/test_settle_e2e.py
@@ -66,6 +66,30 @@ def test_should_return_json_response_with_balances_transfers_and_chart():
     assert data["chart"]["labels"] == ["Alice", "Bob", "Carol"]
 
 
+def test_should_return_501_when_optimize_exact_not_implemented():
+    client = TestClient(app)
+    payload = {
+        "people": ["Alice", "Bob", "Carol"],
+        "base_currency": "USD",
+        "rates": {"USD": "1", "CHF": "1.10", "EUR": "1.08"},
+        "rounding": {"mode": "HALF_UP", "places": 2},
+        "expenses": [
+            {
+                "id": "e1",
+                "payer": "Alice",
+                "amount": "90",
+                "currency": "CHF",
+                "participants": ["Alice", "Bob"],
+                "note": "Swiss pass",
+            }
+        ],
+        "optimize": "exact",
+    }
+    resp = client.post("/api/settle", json=payload)
+    assert resp.status_code == 501
+    assert resp.json() == {"detail": "exact mode not implemented"}
+
+
 def test_should_validate_payload_and_return_422_on_bad_input():
     client = TestClient(app)
     payload = {


### PR DESCRIPTION
## Summary
- raise HTTP 501 when `optimize` is not `greedy`
- cover unsupported exact mode with e2e test
- document unsupported exact mode in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c04265a67883278f91956f34a7de8a