### PR TITLE
feat(validation): reject duplicate participants

### DIFF
--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -24,7 +24,10 @@ def validate_currency_present(currency: str, rates: Mapping[str, Decimal]) -> No
 
 
 def validate_participants_subset(participants: Iterable[str], people: Iterable[str]) -> None:
-    pset = set(participants)
+    plist = list(participants)
+    if len(plist) != len(set(plist)):
+        raise InvalidParticipantsError("participants must be unique")
+    pset = set(plist)
     if not pset.issubset(set(people)):
         raise InvalidParticipantsError("participants must be subset of people")
     if len(pset) == 0:


### PR DESCRIPTION
## Summary
- ensure `validate_participants_subset` rejects duplicate names
- cover duplicate participants with unit test

## Testing
- `ruff check app/utils/validation.py tests/test_settle_unit.py`
- `black app/utils/validation.py tests/test_settle_unit.py`
- `mypy app/utils/validation.py --ignore-missing-imports`
- `PYTHONPATH=. pytest tests/test_settle_unit.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ValidationError for Transfer)*

------
https://chatgpt.com/codex/tasks/task_b_68c042649d7c8327a3d24777b748b573