### PR TITLE
refactor: optimize greedy transfers with heap

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -31,7 +31,14 @@ def settle(payload: SettleRequest) -> SettleResponse:
 
     balances = [Balance(person=p, amount=a) for p, a in balances_map.items()]
     transfers = [
-        Transfer(from_=t["from"], to=t["to"], amount=t["amount"], currency=payload.base_currency)
+        Transfer.model_validate(
+            {
+                "from": t["from"],
+                "to": t["to"],
+                "amount": t["amount"],
+                "currency": payload.base_currency,
+            }
+        )
         for t in transfers_raw
     ]
 

--- a/app/domain/settle.py
+++ b/app/domain/settle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import heapq
 from collections.abc import Iterable, Mapping
 from decimal import ROUND_HALF_UP, Decimal
 
@@ -55,8 +56,10 @@ def compute_balances(
         # Shift the discrepancy to the person with the largest absolute remainder pre-rounding
         remainders = {p: balances[p] - rounded[p] for p in rounded}
         # pick the one whose adjustment brings total to zero
-        # If total > 0, we need to reduce someone slightly (take from a creditor -> choose max positive remainder)
-        # If total < 0, we need to increase someone slightly (give to a debtor -> choose most negative remainder)
+        # If total > 0, reduce someone slightly:
+        # take from a creditor -> choose max positive remainder
+        # If total < 0, increase someone slightly:
+        # give to a debtor -> choose most negative remainder
         if total > 0:
             target = max(remainders, key=lambda k: remainders[k])
             rounded[target] -= total
@@ -73,36 +76,32 @@ def suggest_transfers_greedy(
 ) -> list[dict[str, Decimal | str]]:
     # Round balances to cents for transfer computation
     cents = {p: _quantize(a, places) for p, a in balances.items()}
-    creditors: list[tuple[str, Decimal]] = [(p, +amt) for p, amt in cents.items() if amt > 0]
-    debtors: list[tuple[str, Decimal]] = [(p, -amt) for p, amt in cents.items() if amt < 0]
+    # use negative amounts to turn heapq into a max-heap
+    creditors: list[tuple[Decimal, str]] = [(-amt, p) for p, amt in cents.items() if amt > 0]
+    debtors: list[tuple[Decimal, str]] = [(amt, p) for p, amt in cents.items() if amt < 0]
 
-    # Sort descending by amount
-    creditors.sort(key=lambda x: x[1], reverse=True)
-    debtors.sort(key=lambda x: x[1], reverse=True)
+    heapq.heapify(creditors)
+    heapq.heapify(debtors)
 
     transfers: list[dict[str, Decimal | str]] = []
 
     while creditors and debtors:
-        c_name, c_amt = creditors[0]
-        d_name, d_amt = debtors[0]
+        c_amt_neg, c_name = heapq.heappop(creditors)
+        d_amt_neg, d_name = heapq.heappop(debtors)
+
+        c_amt = -c_amt_neg
+        d_amt = -d_amt_neg
         x = min(c_amt, d_amt)
 
         if x > 0:
             transfers.append({"from": d_name, "to": c_name, "amount": _quantize(x, places)})
 
-        # Update lists
-        if c_amt > d_amt:
-            creditors[0] = (c_name, c_amt - x)
-            debtors.pop(0)
-        elif d_amt > c_amt:
-            debtors[0] = (d_name, d_amt - x)
-            creditors.pop(0)
-        else:
-            creditors.pop(0)
-            debtors.pop(0)
+        c_remaining = c_amt - x
+        d_remaining = d_amt - x
 
-        # Re-sort to always pick the largest remaining
-        creditors.sort(key=lambda y: y[1], reverse=True)
-        debtors.sort(key=lambda y: y[1], reverse=True)
+        if c_remaining > 0:
+            heapq.heappush(creditors, (-c_remaining, c_name))
+        if d_remaining > 0:
+            heapq.heappush(debtors, (-d_remaining, d_name))
 
     return transfers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_settle_performance.py
+++ b/tests/test_settle_performance.py
@@ -1,0 +1,52 @@
+import random
+import time
+from decimal import Decimal
+
+from app.domain.settle import suggest_transfers_greedy
+
+
+def old_suggest_transfers_greedy(balances, places=2):
+    from app.domain.settle import _quantize
+
+    cents = {p: _quantize(a, places) for p, a in balances.items()}
+    creditors = [(p, +amt) for p, amt in cents.items() if amt > 0]
+    debtors = [(p, -amt) for p, amt in cents.items() if amt < 0]
+    creditors.sort(key=lambda x: x[1], reverse=True)
+    debtors.sort(key=lambda x: x[1], reverse=True)
+    transfers = []
+    while creditors and debtors:
+        c_name, c_amt = creditors[0]
+        d_name, d_amt = debtors[0]
+        x = min(c_amt, d_amt)
+        if x > 0:
+            transfers.append({"from": d_name, "to": c_name, "amount": x})
+        if c_amt > d_amt:
+            creditors[0] = (c_name, c_amt - x)
+            debtors.pop(0)
+        elif d_amt > c_amt:
+            debtors[0] = (d_name, d_amt - x)
+            creditors.pop(0)
+        else:
+            creditors.pop(0)
+            debtors.pop(0)
+        creditors.sort(key=lambda y: y[1], reverse=True)
+        debtors.sort(key=lambda y: y[1], reverse=True)
+    return transfers
+
+
+def test_heap_greedy_is_faster():
+    random.seed(0)
+    N = 1000
+    balances = {f"p{i}": Decimal(random.randint(-1000, 1000)) for i in range(N)}
+    s = sum(balances.values())
+    balances["p0"] -= s
+
+    start = time.perf_counter()
+    old_suggest_transfers_greedy(balances.copy())
+    old_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    suggest_transfers_greedy(balances.copy())
+    new_time = time.perf_counter() - start
+
+    assert new_time < old_time


### PR DESCRIPTION
## Summary
- optimize `suggest_transfers_greedy` using heap-based max-heap instead of repeated sorting
- validate transfers via alias-friendly `Transfer` construction
- add performance test comparing heap vs sort implementations

## Testing
- `ruff check app/domain/settle.py app/api.py tests/test_settle_performance.py tests/conftest.py`
- `black app/domain/settle.py app/api.py tests/test_settle_performance.py tests/conftest.py`
- `pytest tests/test_settle_performance.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c04262705483278884bc1184e10f5c